### PR TITLE
Fixed a typo

### DIFF
--- a/flutter_dropzone/README.md
+++ b/flutter_dropzone/README.md
@@ -33,7 +33,7 @@ Stack(
 ## Using it in cross-platform apps
 
 It's a federated plugin, meaning that it will compile in cross platform apps that contain both Android/iOS and Web code.
-It will *not* function on the latter, the view will simply return an error text instead of a drop zone. Use `if (kIsWeb)` from
+It will *not* function on the former, the view will simply return an error text instead of a drop zone. Use `if (kIsWeb)` from
 `import 'package:flutter/foundation.dart'` to only use it in Flutter Web. Still, the same app will still compile to
 Android and iOS, without the usual `dart:html` errors (this is what federated plugins are for).
 


### PR DESCRIPTION
Note: "Latter" refers to the pronoun that comes later or near the end and "Former" refers first pronoun.