### PR TITLE
Fix event handlers being added twice on web

### DIFF
--- a/flutter_dropzone_web/lib/assets/flutter_dropzone.js
+++ b/flutter_dropzone_web/lib/assets/flutter_dropzone.js
@@ -14,6 +14,14 @@ class FlutterDropzone {
     if (onLoaded != null) onLoaded();
   }
 
+  updateHandlers(onLoaded, onError, onHover, onDrop, onLeave) {
+    this.onHover = onHover;
+    this.onDrop = onDrop;
+    this.onLeave = onLeave;
+    this.dropMIME = null;
+    this.dropOperation = 'copy';
+  }
+
   dragover_handler(event) {
     event.preventDefault();
     event.dataTransfer.dropEffect = this.dropOperation;
@@ -72,7 +80,10 @@ var flutter_dropzone_web = {
   },
 
   create: function(container, onLoaded, onError, onHover, onDrop, onLeave) {
-    container.FlutterDropzone = new FlutterDropzone(container, onLoaded, onError, onHover, onDrop, onLeave);
+    if (container.FlutterDropzone === undefined)
+      container.FlutterDropzone = new FlutterDropzone(container, onLoaded, onError, onHover, onDrop, onLeave);
+    else
+      container.FlutterDropzone.updateHandlers(onLoaded, onError, onHover, onDrop, onLeave);
   },
 };
 


### PR DESCRIPTION
When the browser window resizes, the widget may get recreated, which causes a
new event listener to be added. We can avoid that by checking, if the
FlutterDropZone is already created and just assign the new handlers in that
case.

In my case that caused a lot of duplicate uploads in my application, whenever a user resized their browser window.