### PR TITLE
Rewrite onDrop handler to handle multi files

### DIFF
--- a/flutter_dropzone_platform_interface/lib/flutter_dropzone_platform_interface.dart
+++ b/flutter_dropzone_platform_interface/lib/flutter_dropzone_platform_interface.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:typed_data';
+import 'dart:html';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -168,8 +169,8 @@ class DropzoneHoverEvent extends DropzoneEvent {
 }
 
 /// Event called when the user drops a file onto the dropzone.
-class DropzoneDropEvent extends DropzoneEvent<dynamic> {
-  DropzoneDropEvent(int viewId, dynamic file) : super(viewId, file);
+class DropzoneDropEvent extends DropzoneEvent<List<dynamic>> {
+  DropzoneDropEvent(int viewId, List<dynamic> files) : super(viewId, files.cast<File>());
 }
 
 /// Event called when the user leaves a dropzone.

--- a/flutter_dropzone_web/lib/assets/flutter_dropzone.js
+++ b/flutter_dropzone_web/lib/assets/flutter_dropzone.js
@@ -36,6 +36,8 @@ class FlutterDropzone {
   drop_handler(event) {
     event.preventDefault();
 
+    var files = [];
+
     if (event.dataTransfer.items) {
       for (var i = 0; i < event.dataTransfer.items.length; i++) {
         var item = event.dataTransfer.items[i];
@@ -45,13 +47,15 @@ class FlutterDropzone {
 
         if (match) {
           var file = event.dataTransfer.items[i].getAsFile();
-          this.onDrop(event, file);
+          files.push(file);
         }
       }
     } else {
       for (var i = 0; i < ev.dataTransfer.files.length; i++)
-        this.onDrop(event, event.dataTransfer.files[i]);
+        files.push(event.dataTransfer.files[i]);
     }
+
+    this.onDrop(event, files);
   }
 
   setMIME(mime) {

--- a/flutter_dropzone_web/lib/flutter_dropzone_web.dart
+++ b/flutter_dropzone_web/lib/flutter_dropzone_web.dart
@@ -129,7 +129,7 @@ class FlutterDropzoneView {
 
   void _onHover(MouseEvent event) => FlutterDropzonePlatform.instance.events.add(DropzoneHoverEvent(viewId));
 
-  void _onDrop(MouseEvent event, File data) => FlutterDropzonePlatform.instance.events.add(DropzoneDropEvent(viewId, data));
+  void _onDrop(MouseEvent event, List<dynamic> data) => FlutterDropzonePlatform.instance.events.add(DropzoneDropEvent(viewId, data));
 
   void _onLeave(MouseEvent event) => FlutterDropzonePlatform.instance.events.add(DropzoneLeaveEvent(viewId));
 }


### PR DESCRIPTION
Currently when onDrop is called each file will be handled separately.
My suggestion is that onDrop returns an array which contains all dropped files.