### PR TITLE
fix: get script url using flutter utility

### DIFF
--- a/flutter_dropzone_web/lib/flutter_dropzone_plugin.dart
+++ b/flutter_dropzone_web/lib/flutter_dropzone_plugin.dart
@@ -30,10 +30,13 @@ class FlutterDropzonePlugin extends FlutterDropzonePlatform {
       final view = _views[viewId] = FlutterDropzoneView(viewId);
       return view.container;
     });
+    // ignore: undefined_prefixed_name
+    final scriptUrl = ui.webOnlyAssetManager.getAssetUrl(
+      'packages/flutter_dropzone_web/assets/flutter_dropzone.js',
+    );
 
     html.document.body!.append(html.ScriptElement()
-      ..src =
-          'assets/packages/flutter_dropzone_web/assets/flutter_dropzone.js' // ignore: unsafe_html
+      ..src = scriptUrl // ignore: unsafe_html
       ..type = 'application/javascript'
       ..defer = true);
   }


### PR DESCRIPTION
In Flutter it is possible to customize the location that assets will be loaded from  (e.g. using `assetBase` meta tag or providing this property to engine initializer directly)
Current solution assumes that script is always under `<rootUrl>/assets/` directory, which is not true if `assetBase` is used. So in the current PR I use `getAssetUrl` utility provided by Flutter that respects `assetBase`

https://github.com/flutter/engine/blob/942909b77001b4904e26aa29e3cac63345108a0a/lib/web_ui/lib/ui_web/src/ui_web/asset_manager.dart#L76-L81