### PR TITLE
fix `pickFiles` not working on web

### DIFF
--- a/flutter_dropzone_web/lib/flutter_dropzone_web.dart
+++ b/flutter_dropzone_web/lib/flutter_dropzone_web.dart
@@ -72,11 +72,12 @@ class FlutterDropzoneView {
     final picker = web.HTMLInputElement();
     final isSafari =
         web.window.navigator.userAgent.toLowerCase().contains('safari');
+    picker.type = 'file';
     if (isSafari) web.document.body!.append(picker);
     picker.multiple = multiple;
     if (mime.isNotEmpty) picker.accept = mime.join(',');
 
-    void onChangeHandler() {
+    void onChangeHandler(web.Event evt) {
       if (picker.files != null) {
         final list = List.generate(
             picker.files!.length, (index) => picker.files!.item(index));
@@ -86,7 +87,7 @@ class FlutterDropzoneView {
       if (isSafari) picker.remove();
     }
 
-    void onCancelHandler() {
+    void onCancelHandler(web.Event evt) {
       completer.complete([]);
       if (isSafari) picker.remove();
     }


### PR DESCRIPTION
The `picker` was simply missing a `type` of `file`. The added function parameters aren't used, but Dart gets upset when trying to use them as callbacks if they don't have it.

Tested in Firefox and Chrome.

Closes #84.