### PR TITLE
Versioning

### DIFF
--- a/flutter_dropzone/CHANGELOG.md
+++ b/flutter_dropzone/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.0.2] - 2024-06-06
+
+* Incremented `flutter_dropzone_web` versioning to apply changes from 4.0.1
+
 ## [4.0.1] - 2024-06-06
 
 * Implement [#88](https://github.com/deakjahn/flutter_dropzone/pull/88).

--- a/flutter_dropzone/pubspec.yaml
+++ b/flutter_dropzone/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dropzone
 description: A drag-and-drop Flutter plugin (Web only).
-version: 4.0.1
+version: 4.0.2
 homepage: https://github.com/deakjahn/flutter_dropzone
 
 environment:

--- a/flutter_dropzone_web/CHANGELOG.md
+++ b/flutter_dropzone_web/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [4.0.1] - 2024-06-06
+
+* Implement [#88](https://github.com/deakjahn/flutter_dropzone/pull/88).
+* Fix [#84](https://github.com/deakjahn/flutter_dropzone/issues/84).
+
 ## [4.0.0] - 2024-03-31
 
 * Implement [#76](https://github.com/deakjahn/flutter_dropzone/pull/76).

--- a/flutter_dropzone_web/pubspec.yaml
+++ b/flutter_dropzone_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dropzone_web
 description: A drag-and-drop Flutter plugin (Web only).
-version: 4.0.0
+version: 4.0.1
 homepage: https://github.com/deakjahn/flutter_dropzone
 
 environment:


### PR DESCRIPTION
The 4.0.1 changes in `flutter_dropzone_web` weren't published, presumably because the version did not get incremented. This PR should fix that, though maybe @deakjahn would prefer if the versions were consistent between the two packages? 

Just bringing up the issue. Feel free to ignore this PR and fix the versioning however you'd like.